### PR TITLE
Update Mod Packages to use Optional Packages Schema AND Fix Update Settings + OS + Schema mismatch Bugs

### DIFF
--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Package.appxmanifest
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="AppInstallerFileBuilder" Publisher="CN=MSIX-Toolkit-Tempkey" Version="1.2019.524.0" />
+  <Identity Name="AppInstallerFileBuilder" Publisher="CN=MSIX-Toolkit-Tempkey" Version="1.2019.812.0" />
   <mp:PhoneIdentity PhoneProductId="4a19f631-5573-4e7d-9544-322a5adf9868" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AppInstaller File Builder (Preview)</DisplayName>

--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/GenerateXMLView.xaml.cs
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/GenerateXMLView.xaml.cs
@@ -445,7 +445,13 @@ namespace AppInstallerFileBuilder.Views
                         //DataContractSerializer onLaunchDCS = new DataContractSerializer(typeof(OnLaunch));
                         //onLaunchDCS.WriteStartObject(xdw, onLaunch);
                         xdw.WriteStartElement("OnLaunch");
-                        xdw.WriteAttributeString("HoursBetweenUpdateChecks", onLaunch.HoursBetweenUpdateChecks.ToString());
+
+                        //HoursBetweenUpdate checks is only available AFTER 1709
+                        if(!App.AppInstallerFileSchemaNamespace.Equals("http://schemas.microsoft.com/appx/appinstaller/2017"))
+                        {
+                            xdw.WriteAttributeString("HoursBetweenUpdateChecks", onLaunch.HoursBetweenUpdateChecks.ToString());
+                        }
+                        
                         if (onLaunch.IsShowPrompt)
                             xdw.WriteAttributeString("ShowPrompt", onLaunch.IsShowPrompt.ToString().ToLower());
                         if (onLaunch.IsBlockUpdate)

--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/GenerateXMLView.xaml.cs
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/GenerateXMLView.xaml.cs
@@ -179,124 +179,125 @@ namespace AppInstallerFileBuilder.Views
                     }
 
                     //Optional Packages Content
-                    ObservableCollection<OptionalPackage> optionalPackages = App.OptionalPackages; 
+                    ObservableCollection<OptionalPackage> optionalPackages = App.OptionalPackages;
                     //DataContractSerializer optionalPackageDCS = new DataContractSerializer(typeof(OptionalPackage));
-                    
-                    if (optionalPackages.Count > 0 && App.IsOptionalPackages)
-                    {
-                        xdw.WriteStartElement("OptionalPackages");
-                        //optionalPackageDCS.WriteStartObject(xdw, optionalPackages[0]);
-                        for (int i = 0; i < optionalPackages.Count; i++)
-                        {
-                            //Write package or bundle element
-                            if (optionalPackages[i].PackageType == PackageType.MSIX)
-                            {
-                                Package package = new Package(
-                                    optionalPackages[i].FilePath,
-                                    optionalPackages[i].Version,
-                                    optionalPackages[i].Publisher,
-                                    optionalPackages[i].Name,
-                                    optionalPackages[i].PackageType,
-                                    optionalPackages[i].ProcessorArchitecture
-                                );
-
-                                //DataContractSerializer packageDCS = new DataContractSerializer(typeof(Package));
-                                xdw.WriteStartElement("Package");
-                                //packageDCS.WriteStartObject(xdw, package);
-                                xdw.WriteAttributeString("Version", package.Version);
-                                xdw.WriteAttributeString("Uri", package.FilePath);
-                                xdw.WriteAttributeString("Publisher", package.Publisher);
-                                if (package.ProcessorArchitecture != "" && package.PackageType != PackageType.MSIXBUNDLE)
-                                {
-                                    xdw.WriteAttributeString("ProcessorArchitecture", package.ProcessorArchitecture.ToString());
-                                }
-                                xdw.WriteAttributeString("Name", package.Name);
-                                //packageDCS.WriteEndObject(xdw);
-                                xdw.WriteEndElement();
-                            }
-                            else if (optionalPackages[i].PackageType == PackageType.MSIXBUNDLE)
-                            {
-                                Bundle bundle = new Bundle(
-                                     optionalPackages[i].FilePath,
-                                    optionalPackages[i].Version,
-                                    optionalPackages[i].Publisher,
-                                    optionalPackages[i].Name,
-                                    optionalPackages[i].PackageType
-                                );
-
-                                //DataContractSerializer bundleDCS = new DataContractSerializer(typeof(Bundle));
-                                //bundleDCS.WriteStartObject(xdw, bundle);
-                                xdw.WriteStartElement("Bundle");
-                                xdw.WriteAttributeString("Version", bundle.Version);
-                                xdw.WriteAttributeString("Uri", bundle.FilePath);
-                                xdw.WriteAttributeString("Publisher", bundle.Publisher);
-                                xdw.WriteAttributeString("Name", bundle.Name);
-                                //bundleDCS.WriteEndObject(xdw);
-                                xdw.WriteEndElement();
-                            }
-                        }
-                        //optionalPackageDCS.WriteEndObject(xdw);
-                        xdw.WriteEndElement();
-                    }
-
 
                     //Modification Packages Content
                     ObservableCollection<ModificationPackage> modificationPackages = App.ModificationPackages;
-                    //DataContractSerializer modificationPackageDCS = new DataContractSerializer(typeof(ModificationPackage));
-                    if (modificationPackages.Count > 0 && App.IsModificationPackages)
+
+                    bool hasOptionalPackage = (optionalPackages.Count > 0 && App.IsOptionalPackages);
+                    bool hasModificationPackage = (modificationPackages.Count > 0 && App.IsModificationPackages);
+
+                    if (hasOptionalPackage || hasModificationPackage)
                     {
-                        xdw.WriteStartElement("ModificationPackages");
-                        //modificationPackageDCS.WriteStartObject(xdw, modificationPackages[0]);
-                        for (int i = 0; i < modificationPackages.Count; i++)
+                        xdw.WriteStartElement("OptionalPackages");
+                        //optionalPackageDCS.WriteStartObject(xdw, optionalPackages[0]);
+                        if (hasOptionalPackage)
                         {
-                            //Write package or bundle element
-                            if (modificationPackages[i].PackageType == PackageType.MSIX)
+                            for (int i = 0; i < optionalPackages.Count; i++)
                             {
-                                Package package = new Package(
-                                    modificationPackages[i].FilePath,
-                                    modificationPackages[i].Version,
-                                    modificationPackages[i].Publisher,
-                                    modificationPackages[i].Name,
-                                    modificationPackages[i].PackageType,
-                                    modificationPackages[i].ProcessorArchitecture
-                                );
-
-                                //DataContractSerializer packageDCS = new DataContractSerializer(typeof(Package));
-                                //packageDCS.WriteStartObject(xdw, package);
-                                xdw.WriteStartElement("Package");
-                                xdw.WriteAttributeString("Version", package.Version);
-                                xdw.WriteAttributeString("Uri", package.FilePath);
-                                xdw.WriteAttributeString("Publisher", package.Publisher);
-                                if (package.ProcessorArchitecture != "" && package.PackageType != PackageType.MSIXBUNDLE)
+                                //Write package or bundle element
+                                if (optionalPackages[i].PackageType == PackageType.MSIX)
                                 {
-                                    xdw.WriteAttributeString("ProcessorArchitecture", package.ProcessorArchitecture.ToString());
-                                }
-                                xdw.WriteAttributeString("Name", package.Name);
-                                //packageDCS.WriteEndObject(xdw);
-                                xdw.WriteEndElement();
-                            }
-                            else if (modificationPackages[i].PackageType == PackageType.MSIXBUNDLE)
-                            {
-                                Bundle bundle = new Bundle(
-                                     modificationPackages[i].FilePath,
-                                    modificationPackages[i].Version,
-                                    modificationPackages[i].Publisher,
-                                   modificationPackages[i].Name,
-                                    modificationPackages[i].PackageType
-                                );
+                                    Package package = new Package(
+                                        optionalPackages[i].FilePath,
+                                        optionalPackages[i].Version,
+                                        optionalPackages[i].Publisher,
+                                        optionalPackages[i].Name,
+                                        optionalPackages[i].PackageType,
+                                        optionalPackages[i].ProcessorArchitecture
+                                    );
 
-                                //DataContractSerializer bundleDCS = new DataContractSerializer(typeof(Bundle));
-                                //bundleDCS.WriteStartObject(xdw, bundle);
-                                xdw.WriteStartElement("Bundle");
-                                xdw.WriteAttributeString("Version", bundle.Version);
-                                xdw.WriteAttributeString("Uri", bundle.FilePath);
-                                xdw.WriteAttributeString("Publisher", bundle.Publisher);
-                                xdw.WriteAttributeString("Name", bundle.Name);
-                                //bundleDCS.WriteEndObject(xdw);
-                                xdw.WriteEndElement();
+                                    //DataContractSerializer packageDCS = new DataContractSerializer(typeof(Package));
+                                    xdw.WriteStartElement("Package");
+                                    //packageDCS.WriteStartObject(xdw, package);
+                                    xdw.WriteAttributeString("Version", package.Version);
+                                    xdw.WriteAttributeString("Uri", package.FilePath);
+                                    xdw.WriteAttributeString("Publisher", package.Publisher);
+                                    if (package.ProcessorArchitecture != "" && package.PackageType != PackageType.MSIXBUNDLE)
+                                    {
+                                        xdw.WriteAttributeString("ProcessorArchitecture", package.ProcessorArchitecture.ToString());
+                                    }
+                                    xdw.WriteAttributeString("Name", package.Name);
+                                    //packageDCS.WriteEndObject(xdw);
+                                    xdw.WriteEndElement();
+                                }
+                                else if (optionalPackages[i].PackageType == PackageType.MSIXBUNDLE)
+                                {
+                                    Bundle bundle = new Bundle(
+                                         optionalPackages[i].FilePath,
+                                        optionalPackages[i].Version,
+                                        optionalPackages[i].Publisher,
+                                        optionalPackages[i].Name,
+                                        optionalPackages[i].PackageType
+                                    );
+
+                                    //DataContractSerializer bundleDCS = new DataContractSerializer(typeof(Bundle));
+                                    //bundleDCS.WriteStartObject(xdw, bundle);
+                                    xdw.WriteStartElement("Bundle");
+                                    xdw.WriteAttributeString("Version", bundle.Version);
+                                    xdw.WriteAttributeString("Uri", bundle.FilePath);
+                                    xdw.WriteAttributeString("Publisher", bundle.Publisher);
+                                    xdw.WriteAttributeString("Name", bundle.Name);
+                                    //bundleDCS.WriteEndObject(xdw);
+                                    xdw.WriteEndElement();
+                                }
                             }
                         }
-                        //modificationPackageDCS.WriteEndObject(xdw);
+
+                        if (hasModificationPackage)
+                        {
+                            for (int i = 0; i < modificationPackages.Count; i++)
+                            {
+                                //Write package or bundle element
+                                if (modificationPackages[i].PackageType == PackageType.MSIX)
+                                {
+                                    Package package = new Package(
+                                        modificationPackages[i].FilePath,
+                                        modificationPackages[i].Version,
+                                        modificationPackages[i].Publisher,
+                                        modificationPackages[i].Name,
+                                        modificationPackages[i].PackageType,
+                                        modificationPackages[i].ProcessorArchitecture
+                                    );
+
+                                    //DataContractSerializer packageDCS = new DataContractSerializer(typeof(Package));
+                                    //packageDCS.WriteStartObject(xdw, package);
+                                    xdw.WriteStartElement("Package");
+                                    xdw.WriteAttributeString("Version", package.Version);
+                                    xdw.WriteAttributeString("Uri", package.FilePath);
+                                    xdw.WriteAttributeString("Publisher", package.Publisher);
+                                    if (package.ProcessorArchitecture != "" && package.PackageType != PackageType.MSIXBUNDLE)
+                                    {
+                                        xdw.WriteAttributeString("ProcessorArchitecture", package.ProcessorArchitecture.ToString());
+                                    }
+                                    xdw.WriteAttributeString("Name", package.Name);
+                                    //packageDCS.WriteEndObject(xdw);
+                                    xdw.WriteEndElement();
+                                }
+                                else if (modificationPackages[i].PackageType == PackageType.MSIXBUNDLE)
+                                {
+                                    Bundle bundle = new Bundle(
+                                         modificationPackages[i].FilePath,
+                                        modificationPackages[i].Version,
+                                        modificationPackages[i].Publisher,
+                                       modificationPackages[i].Name,
+                                        modificationPackages[i].PackageType
+                                    );
+
+                                    //DataContractSerializer bundleDCS = new DataContractSerializer(typeof(Bundle));
+                                    //bundleDCS.WriteStartObject(xdw, bundle);
+                                    xdw.WriteStartElement("Bundle");
+                                    xdw.WriteAttributeString("Version", bundle.Version);
+                                    xdw.WriteAttributeString("Uri", bundle.FilePath);
+                                    xdw.WriteAttributeString("Publisher", bundle.Publisher);
+                                    xdw.WriteAttributeString("Name", bundle.Name);
+                                    //bundleDCS.WriteEndObject(xdw);
+                                    xdw.WriteEndElement();
+                                }
+                            }
+                        }                       
+                        //optionalPackageDCS.WriteEndObject(xdw);
                         xdw.WriteEndElement();
                     }
 

--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml
@@ -201,33 +201,25 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" x:Name="One_Update_Settings_Stack_Panel" x:Uid="One_Update_Settings_Stack_Panel" Visibility="Collapsed">
-                        <TextBlock
+                          
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal" x:Name="Two_Update_Settings_Stack_Panel" x:Uid="Two_Update_Settings_Stack_Panel" Visibility="Collapsed">
+                            <TextBlock
                             x:Uid="Update_Frequency_Text_Block"
                             Text="Hours between update checks"
                             Style="{StaticResource SubtitleTextBlockStyle}" FontSize="15"
                             Margin="5" VerticalAlignment="Center"
-                        />
-                        <TextBox
+                            />
+                            <TextBox
                             x:Uid="Hours_Between_Updates_Text_Box"
                             x:Name="Hours_Between_Updates_Text_Box"
                             PlaceholderText="12"
                             Width="70"
                             HorizontalAlignment="Left"
                             FontSize="15" Margin="5" VerticalAlignment="Center"
-                        />
-                            
-                        </StackPanel>
-
-                        <StackPanel Orientation="Horizontal" x:Name="Two_Update_Settings_Stack_Panel" x:Uid="Two_Update_Settings_Stack_Panel" Visibility="Collapsed">
-                            <TextBlock Text="Force update" Style="{StaticResource SubtitleTextBlockStyle}" FontSize="15"
-                            Margin="5" VerticalAlignment="Center" />
-                            <ToggleSwitch
-                                Margin="21,0,0,0"
-                                x:Uid="Force_Update_Switch"
-                                x:Name="Force_Update_Switch"
-                                IsOn="{Binding IsForcedUpdate}"
-                                Toggled="Force_Update_Switch_Toggled"
                             />
+                            
                             <TextBlock Text="Auto background update" Style="{StaticResource SubtitleTextBlockStyle}" FontSize="15"
                             Margin="5" VerticalAlignment="Center" />
                             <ToggleSwitch
@@ -240,6 +232,16 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" x:Name="Three_Update_Settings_Stack_Panel" x:Uid="Three_Update_Settings_Stack_Panel" Visibility="Collapsed">
+                            <TextBlock Text="Force update" Style="{StaticResource SubtitleTextBlockStyle}" FontSize="15"
+                            Margin="5" VerticalAlignment="Center" />
+                            <ToggleSwitch
+                                Margin="21,0,0,0"
+                                x:Uid="Force_Update_Switch"
+                                x:Name="Force_Update_Switch"
+                                IsOn="{Binding IsForcedUpdate}"
+                                Toggled="Force_Update_Switch_Toggled"
+                            />
+                            
                             <TextBlock Text="Show prompt" Style="{StaticResource SubtitleTextBlockStyle}" FontSize="15"
                             Margin="5" VerticalAlignment="Center"/>
                             <ToggleSwitch

--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml.cs
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml.cs
@@ -286,7 +286,7 @@ namespace AppInstallerFileBuilder.Views
                 // Will result in a list like {"Win10Ver1709", Win10Ver1803, "Win10Ver1809"}
                 List<String> lStrings = new List<string>
                 {
-                    //although update options{showprompt and blocking updates} are available in 1809, these options were supported in centennial apps till 1903
+                    //although update options{showprompt and blocking updates} are available in 1809, these options were not supported in MSIX packages untill 1903
                     "Windows 10 Version 1903 or later",
                     "Windows 10 Version 1803 or later",
                     "Windows 10 Version 1709 or later"

--- a/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml.cs
+++ b/AppInstallerFileBuilder/AppInstallerFileBuilder/Views/MainPackageView.xaml.cs
@@ -286,7 +286,7 @@ namespace AppInstallerFileBuilder.Views
                 // Will result in a list like {"Win10Ver1709", Win10Ver1803, "Win10Ver1809"}
                 List<String> lStrings = new List<string>
                 {
-                    //although update options{showprompt and blocking updates} are available in 1809, these options were not supported in MSIX packages untill 1903
+                    //although update options {showprompt and blocking updates} are available in 1809, these options were not supported in repackaged MSIX apps until 1903
                     "Windows 10 Version 1903 or later",
                     "Windows 10 Version 1803 or later",
                     "Windows 10 Version 1709 or later"

--- a/AppInstallerFileBuilder/README.md
+++ b/AppInstallerFileBuilder/README.md
@@ -1,6 +1,6 @@
 # AppInstaller File Builder
 
-AppInstaller File Builder is a Windows 10 applications for users to easily build an AppInstaller file. Currently the process of building an AppInstaller file can be error ridden. The app makes this easier by allowing the users to specify the app packages that they would like to distribute, along with the update options.
+AppInstaller File Builder is a Windows 10 application for users to easily build an AppInstaller file. Currently the process of building an AppInstaller file can be error ridden. The app makes this easier by allowing the users to specify the app packages that they would like to distribute, along with the update options.
 
 ## Install the app 
 


### PR DESCRIPTION
Fixes:
1.	ModPackges were being created under an invalid <ModificationPackages> element in the generated AppInstaller file. I made changes to have them added under the <OptionalPackages> element instead.
2.	Update Settings:
a.	HoursBetweenUpdates was showing up as an update option for MinOS Version 1709 and being written in an AppInstaller file referencing the 2017 schema. It was only supported in 1803 so I changed the UI to have it only show up with minOS 1803 selected and also be written when schema is 2017/2 or later.
b.	ForceUpdateFromAnyVersion was showing up as an Update Option for MinOS 1803 and being written in an AppInstaller file referencing the 2017/2 schema. It was only supported 1903 (technically 1809 for UWP but 1903 for Centennial). I changed the UI to have it show up with minOS 1903 selected and be written to an AppInstaller file referencing 2018.
